### PR TITLE
Add options highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ quarto-vim
 
 quarto-vim is a fork of the [vim-rmarkdown](https://github.com/vim-pandoc/vim-rmarkdown) plugin.
 
-quarto-vim currently only handles syntax highlighthing for qmd
+quarto-vim currently only handles syntax highlighting for qmd
 files, however we'd very much like to add more of the features
 available in the excellent [vim-pandoc](https://githhub.com/vim-pandoc/viv-pandoc)
 plugin. If you are interested in contributing please get in
@@ -27,7 +27,7 @@ to your .vimrc, source it, and execute `:PluginInstall`.
 
 ## Usage
 
-Files with the .qmd extension are automatically detected as Quarto files and use highlithing rules from vim-pandoc-syntax (in addition to some special rules for Quarto executable code).
+Files with the .qmd extension are automatically detected as Quarto files and use highlighting rules from vim-pandoc-syntax (in addition to some special rules for Quarto executable code).
 
 ### Syntax
 

--- a/ftdetect/markdown.vim
+++ b/ftdetect/markdown.vim
@@ -1,0 +1,3 @@
+augroup quarto
+   au! BufRead,BufNewFile *.qmd  set filetype=markdown " temporary until quarto treesitter grammar
+augroup END

--- a/ftdetect/quarto.vim
+++ b/ftdetect/quarto.vim
@@ -1,3 +1,3 @@
 augroup quarto
-   au! BufRead,BufNewFile *.qmd  set filetype=quarto
+   au! BufRead,BufNewFile *.qmd  set filetype=markdown " temporary until quarto treesitter grammar
 augroup END

--- a/syntax/quarto.vim
+++ b/syntax/quarto.vim
@@ -16,3 +16,15 @@ exe 'syn region pandocPythonChunk '.
             \'contained containedin=pandocDelimitedCodeblock contains=@python'
 
 syn region pandocInlinePython matchgroup=Operator start=/`python\s/ end=/`/ contains=@Python concealends
+
+exe 'syn region qmdOptions matchgroup=qmdID '.
+            \'start="^#|\s" '.
+            \'end="$" '.
+            \'contained containedin=pandocPythonChunk contains=@Yaml'
+
+exe 'syn region qmdOptions matchgroup=qmdID '.
+            \'start="^#|\s" '.
+            \'end="$" '.
+            \'contained containedin=pandocRChunk contains=@Yaml'
+
+hi link qmdID Constant


### PR DESCRIPTION
Adds YAML syntax highlighting for special options comments in R or Python code blocks. Doesn't affect normal comments, here's an example:

![image](https://user-images.githubusercontent.com/44099524/154839312-be848ae4-2d81-4166-902b-7ae9f65908ce.png)
