### PR TITLE
README.md typo prevents installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ quarto-vim's repo uses the typical bundle layout, so it's very simple to
 install using some plugin manager such as [pathogen](https://github.com/tpope/vim-pathogen), [Vundle](https://github.com/VundleVim/Vundle.vim) or [NeoBundle](https://github.com/Shougo/neobundle.vim). For
 example, using Vundle you should add
 
-    Plugin 'vim-pandoc/vim-pandoc-sytnax'
+    Plugin 'vim-pandoc/vim-pandoc-syntax'
     Plugin 'quarto-dev/quarto-vim'
 
 to your .vimrc, source it, and execute `:PluginInstall`.


### PR DESCRIPTION
2 characters change to fix typo in the README