### PR TITLE
Simpler syntax/quarto.vim: source syntax/rmd.vim

### DIFF
--- a/syntax/quarto.vim
+++ b/syntax/quarto.vim
@@ -1,18 +1,1 @@
-runtime syntax/pandoc.vim
-PandocHighlight r
-" quarto recognizes embedded R differently than regular pandoc
-exe 'syn region pandocRChunk '. 
-            \'start=/\(```\s*{\s*r.*\n\)\@<=\_^/ ' .
-            \'end=/\_$\n\(\(\s\{4,}\)\=\(`\{3,}`*\|\~\{3,}\~*\)\_$\n\_$\)\@=/ '. 
-            \'contained containedin=pandocDelimitedCodeblock contains=@R'
-
-syn region pandocInlineR matchgroup=Operator start=/`r\s/ end=/`/ contains=@R concealends
-
-PandocHighlight python
-" quarto recognizes embedded Python differently than regular pandoc
-exe 'syn region pandocPythonChunk '. 
-            \'start=/\(```\s*{\s*python.*\n\)\@<=\_^/ ' .
-            \'end=/\_$\n\(\(\s\{4,}\)\=\(`\{3,}`*\|\~\{3,}\~*\)\_$\n\_$\)\@=/ '. 
-            \'contained containedin=pandocDelimitedCodeblock contains=@python'
-
-syn region pandocInlinePython matchgroup=Operator start=/`python\s/ end=/`/ contains=@Python concealends
+runtime syntax/rmd.vim


### PR DESCRIPTION
I'm the maintainer of the official `syntax/rmd.vim` and plan to use Quarto instead of RMarkdown when writing academic papers. I make any change to Vim runtime files in the R-Vim-runtime repository before sending them to Bram Moolenaar. In a new branch, I'm improving the `syntax/rmd.vim`, but the [`syntax/quarto.vim`](https://github.com/jalvesaq/R-Vim-runtime/blob/quarto/syntax/quarto.vim) is simply:

```vim
runtime syntax/rmd.vim
```

And what the `syntax/rmd.vim` does is:

  1. Set the value of `g:pandoc#syntax#codeblocks#embeds#langs` to `[]` to avoid embedding the syntax of languages (R and Python) in code blocks that later have to be either discarded or ignored because `syntax/pandoc.vim` doesn't recognize RMarkdown code block delimiters.

  2. Try to Source `syntax/pandoc.vim`.

  3. If `syntax/pandoc.vim` isn't found:

     3.1 Set the value of `g:markdown_fenced_languages` to `[]` and source `syntax/markdown.vim`.

     3.2 Add highlighting for the YAML header and for citations.

  4. Add highlighting for fenced code blocks.

What do you think about the above approach?

Is there any syntax that is specific to Quarto and that would not work on RMarkdown, that is, that should be included `syntax/quarto.vim`, after sourcing `syntax/rmd.vim`?

I believe that it would be better if we could agree on a single `syntax/quarto.vim` and, then, send it to Bram Moolenaar to make it part of the official runtime files.